### PR TITLE
Can run on any specified port in specified .yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Hermes is a network simulation framework for testing and developing network prot
 
 ## Usage
 
+### Single Simulation 
 To run a simulation, use the following command:
 
 ```bash
@@ -14,6 +15,16 @@ pip install -r requirements.txt
 
 # Run the simulation
 python3 src/main.py -c <path_to_config_file> -l <path_to_log_dir>
+```
+
+### Multi-Process Simulation
+To run multiple simulations simultaneously on one machine:
+```bash
+# Run multiple simulations at once
+python3 src/main.py -c <config_file1> <config_file2> [config_file3...]
+
+# Example: Run two network nodes
+python3 src/main.py -c scripts/prod_config.yml scripts/test_config.yml
 ```
 
 ## WebSocket Server

--- a/scripts/prod_config.yml
+++ b/scripts/prod_config.yml
@@ -1,15 +1,14 @@
 config:
   protocol: tree
+  web_socket_port: 6364
   log_dir: /opt/hermes/logs
   log_level:
     websocket_server: info
     alice: info
     charlie: info
-  node_id: sahas
+  node_id: sumanth
 ports:
+  - name: en1
+    interface: en1
   - name: en2
     interface: en2
-  - name: en3
-    interface: en3
-  - name: en4
-    interface: en4

--- a/scripts/prod_config.yml
+++ b/scripts/prod_config.yml
@@ -9,6 +9,6 @@ config:
   node_id: sumanth
 ports:
   - name: en1
-    interface: en1
+    interface: "127.0.0.1:8001:8002"
   - name: en2
-    interface: en2
+    interface: "127.0.0.1:8003:8004"

--- a/src/hermes/sim/Sim.py
+++ b/src/hermes/sim/Sim.py
@@ -148,7 +148,7 @@ class Sim:
                     signal_q=signal_q
                 ),
                 faultInjector=faultInjector,
-                protocolClass=ChunkProtocol
+                protocolClass=EthernetProtocol
             )
         )
 

--- a/src/hermes/sim/Sim.py
+++ b/src/hermes/sim/Sim.py
@@ -48,13 +48,14 @@ class Sim:
         if 'node_id' in config_settings:
             sim.node_id = config_settings['node_id']
         
-        sim.thread_manager.add_websocket_server(WebSocketServer())
+        sim.thread_manager.add_websocket_server(WebSocketServer(port=config_settings.get('web_socket_port', 6363)))
         sim.thread_manager.add_agent(Agent(sim.node_id, sim.thread_manager))
 
 
         for port_config in config['ports']:
             if port_config.get('type', '') == 'disconnected':
                 continue
+            
             # Create a port, with pipes and a thread. Add the port to the thread manager
             sim._create_port(port_config)
         

--- a/src/hermes/sim/WebSocketServer.py
+++ b/src/hermes/sim/WebSocketServer.py
@@ -81,6 +81,7 @@ class WebSocketServer:
         
         try:
             # Don't use a context manager - directly create the server
+        
             self.server = await serve(
                 self.handle_client, 
                 self.host, 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from hermes.sim.Sim import Sim
 
 import argparse
 import yaml
+from multiprocessing import Process
 
 def load_config(config_file):
     """Load and parse a YAML configuration file. """
@@ -16,14 +17,33 @@ def load_config(config_file):
     except FileNotFoundError:
         print(f"Configuration file {config_file} not found")
         return None
-
+    
+def run_sim_from_config(path: str):
+    """Single thread simulation run from a configuration file."""
+    config = load_config(path)
+    sim = Sim.from_config(config)
+    asyncio.run(sim.run())
+        
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Alternating Bit Protocol Implementation')
-    parser.add_argument('--config_file', '-c', type=str, help='Path to the YAML configuration file')
+    parser.add_argument(
+        '--config_files', '-c',
+        nargs='+',
+        type=str,
+        help="Paths to YAML configuration files (space-separated.)"
+    )
+    
     args = parser.parse_args()
 
-    if args.config_file:
-        config = load_config(args.config_file)
-        sim = Sim.from_config(config)
-        asyncio.run(sim.run())
+    processes = []
+    for path in args.config_files:
+        p = Process(target=run_sim_from_config, args=(path,))
+        p.start()
+        print(f"Started simulation process for {path} with PID {p.pid}")
+        processes.append(p)
+    
+    for p in processes:
+        p.join()
+        print(f"Simulation process for {p.pid} has finished.")
+        
         


### PR DESCRIPTION
This PR adds support for running multiple WebSocket servers on any port specified in the provided `.yml` configuration file when launching main.py.

Example Usage:
```bash
python main.py -c test_config.yml prod_config.yml ...
```

test_config.yml: 
```yml
config:
     ....
     web_socket_port: 1234
ports:
  - name: en1
    interface: "127.0.0.1:8002:8001"  
  - name: en2
    interface: "127.0.0.1:8004:8003"  
```
It will specify the following when run:
```bash
Started simulation process for scripts/prod_config.yml with PID 7424
Started simulation process for scripts/test_config.yml with PID 7425
```
this means you can kill individual processes with `kill PID`

This allows multiple WebSocket servers to be run concurrently on a single machine, each bound to a different port.